### PR TITLE
fix: 日付処理のJST対応とプロジェクト切替時のタスク自動選択

### DIFF
--- a/server/src/controllers/timeEntries.firestore.ts
+++ b/server/src/controllers/timeEntries.firestore.ts
@@ -5,6 +5,15 @@ import User from '../models/firestore/User.js';
 import { AuthRequestFirestore } from '../types/firestore.js';
 import { Timestamp } from '@google-cloud/firestore';
 
+// タイムゾーンの影響を受けずにJSTで今日の日付を取得
+const getTodayDateString = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 // @desc    Get all time entries
 // @route   GET /api/v2/time-entries
 // @access  Private/Admin
@@ -427,7 +436,7 @@ export const startTimer = async (req: AuthRequestFirestore, res: Response): Prom
       projectId: req.body.projectId,
       task: req.body.task || req.body.taskId,  // Store as 'task' field for consistency
       taskId: req.body.taskId || req.body.task,
-      date: new Date().toISOString().split('T')[0],
+      date: getTodayDateString(), // JST で今日の日付を取得
       startTime: Timestamp.now(),
       duration: 0,
       notes: req.body.notes || '',

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -74,15 +74,19 @@ const Reports = () => {
   const [reportGenerated, setReportGenerated] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
 
-  // Calculate date range
+  // Calculate date range (タイムゾーンの影響を受けないように文字列で直接構築)
   const getDateRange = useCallback(() => {
-    // Always use selected year and month
-    const startOfMonth = new Date(selectedYear, selectedMonth - 1, 1);
-    const endOfMonth = new Date(selectedYear, selectedMonth, 0);
-    return {
-      startDate: startOfMonth.toISOString().split('T')[0],
-      endDate: endOfMonth.toISOString().split('T')[0]
-    };
+    const year = selectedYear;
+    const month = selectedMonth;
+
+    // 月の最初の日
+    const startDate = `${year}-${String(month).padStart(2, '0')}-01`;
+
+    // 月の最後の日を計算
+    const lastDay = new Date(year, month, 0).getDate();
+    const endDate = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+
+    return { startDate, endDate };
   }, [selectedYear, selectedMonth]);
 
   // Generate report


### PR DESCRIPTION
## 概要

日付処理におけるタイムゾーン問題を修正し、TimeTrackingページのUX改善を実施しました。

## 変更内容

### 日付処理のJST対応

**問題**: `toISOString()`がUTCに変換するため、JST 00:30に作成したデータが前日として保存されていた

**修正箇所**:
- `src/pages/Reports.tsx` - 月の開始日・終了日の計算をJST対応に修正
- `src/pages/TimeTracking.tsx` - 今日の日付取得処理を全てJST対応に修正（5箇所）
- `server/src/controllers/timeEntries.firestore.ts` - タイマー開始時の日付をJST対応に修正

**技術的な解決策**: 
- `new Date().toISOString().split('T')[0]` → `getTodayDateString()` ヘルパー関数に置き換え
- タイムゾーンに依存せず、ローカル時刻（JST）の年月日を直接文字列で構築

### TimeTrackingページのUX改善

**実装内容**:
- プロジェクト切替時に、そのプロジェクトの1つ目のタスクを自動選択
- 編集モードでない場合のみ自動選択（編集中は選択を維持）

**修正箇所**:
- `src/pages/TimeTracking.tsx:85-106` - useEffectにタスク自動選択ロジックを追加

## データの保存形式

- Firestoreの`date`フィールドは文字列（YYYY-MM-DD形式）で保存
- 修正により、JSTの正しい日付が保存されるようになりました

## テスト

- [x] サーバー（TypeScript）: ビルド成功
- [x] フロントエンド（Vite）: ビルド成功
- [ ] 実際の環境での動作確認が必要

## 影響範囲

- 日付処理に関わる全ての機能（Reports、TimeTracking）
- タイマー機能の日付記録
- 過去データには影響なし（新規作成分から適用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
