### PR TITLE
fix: 日付選択後にタイムエントリー保存しても選択日付を維持

### DIFF
--- a/src/pages/TimeTracking.tsx
+++ b/src/pages/TimeTracking.tsx
@@ -712,12 +712,11 @@ const TimeTracking = () => {
         });
       }
 
-      // フォームをリセット（プロジェクトとタスクは保持）
+      // フォームをリセット（プロジェクトとタスクと日付は保持）
       setSelectedTimeEntry(null);
       setDuration('');
       setNotes('');
-      // プロジェクトとタスクは選択状態を維持
-      setDate(getTodayDateString());
+      // プロジェクト、タスク、日付は選択状態を維持
 
     } catch (error) {
       toast({
@@ -859,7 +858,7 @@ const TimeTracking = () => {
   // 編集をキャンセル
   const handleCancelEdit = () => {
     setSelectedTimeEntry(null);
-    setDate(getTodayDateString());
+    // 日付は現在選択している日付を維持
     // プロジェクトとタスクは保存された値に戻す
     setSelectedProjectId(localStorage.getItem('timeTracking_selectedProjectId') || '');
     setSelectedTaskId(localStorage.getItem('timeTracking_selectedTaskId') || '');


### PR DESCRIPTION
タイムエントリーの保存後やキャンセル後に自動的に当日に戻る問題を修正。
ユーザーが選択した日付に留まるように変更。

- handleSaveTimeEntry: 保存後の setDate(getTodayDateString()) を削除
- handleCancelEdit: キャンセル後の setDate(getTodayDateString()) を削除

Slack thread: https://siekjp.slack.com/archives/C0A2BPQ4BJS/p1771246668021659

https://claude.ai/code/session_017A8oQ4WggRP5nLRHRrkKTD