### PR TITLE
feat: プロジェクトコードとタスクサブコードの追加

### DIFF
--- a/server/register-project-codes.mjs
+++ b/server/register-project-codes.mjs
@@ -1,0 +1,253 @@
+/**
+ * プロジェクトコードとタスクサブコードの一括登録スクリプト
+ *
+ * 機能:
+ *   1. メモ（notes）内のコード候補を検出して自動設定
+ *   2. コード候補がない場合、プロジェクト名からコードを自動生成
+ *   3. タスクのサブコードも自動生成
+ *   4. --dry-run オプションで変更内容のプレビューのみ
+ *
+ * 実行方法:
+ *   cd server
+ *
+ *   # プレビュー（変更なし）
+ *   GOOGLE_CLOUD_PROJECT=harvest-a82c0 node register-project-codes.mjs --dry-run
+ *
+ *   # 実行（Firestoreに書き込み）
+ *   GOOGLE_CLOUD_PROJECT=harvest-a82c0 node register-project-codes.mjs
+ *
+ *   # 特定のプロジェクトにコードを指定して登録
+ *   GOOGLE_CLOUD_PROJECT=harvest-a82c0 node register-project-codes.mjs --set PROJECT_ID=CODE
+ *
+ *   # 上書きモード（既存コードも更新）
+ *   GOOGLE_CLOUD_PROJECT=harvest-a82c0 node register-project-codes.mjs --force
+ */
+
+import { Firestore, Timestamp } from '@google-cloud/firestore';
+
+const projectId = 'harvest-a82c0';
+const db = new Firestore({ projectId });
+
+// コマンドライン引数の解析
+const args = process.argv.slice(2);
+const isDryRun = args.includes('--dry-run');
+const isForce = args.includes('--force');
+
+// --set PROJECT_ID=CODE 形式の手動指定を解析
+const manualCodes = new Map();
+args.forEach((arg, index) => {
+  if (arg === '--set' && args[index + 1]) {
+    const [projId, code] = args[index + 1].split('=');
+    if (projId && code) {
+      manualCodes.set(projId, code);
+    }
+  }
+});
+
+/**
+ * プロジェクト名からコードを自動生成
+ * 例: "ウェブサイトリニューアル" → "WEB"（英語部分があれば使用）
+ *     "Project Alpha" → "PA"
+ *     "プロジェクトA" → "PJA"
+ */
+function generateCodeFromName(name, existingCodes) {
+  // 英語の単語を抽出
+  const englishWords = name.match(/[A-Za-z]+/g) || [];
+
+  let baseCode = '';
+
+  if (englishWords.length > 0) {
+    if (englishWords.length === 1) {
+      // 単語が1つなら最初の3-4文字
+      baseCode = englishWords[0].substring(0, 4).toUpperCase();
+    } else {
+      // 複数単語なら頭文字を結合
+      baseCode = englishWords.map(w => w[0]).join('').toUpperCase();
+      if (baseCode.length < 2) baseCode = englishWords[0].substring(0, 3).toUpperCase();
+    }
+  } else {
+    // 英語がない場合は「PJ」＋連番
+    baseCode = 'PJ';
+  }
+
+  // 重複チェック、重複する場合は連番を付与
+  let code = baseCode;
+  let counter = 1;
+  while (existingCodes.has(code)) {
+    counter++;
+    code = `${baseCode}${counter}`;
+  }
+
+  return code;
+}
+
+async function registerProjectCodes() {
+  try {
+    console.log(isDryRun
+      ? '=== プレビューモード（変更なし） ==='
+      : '=== プロジェクトコード一括登録 ===');
+    console.log('');
+
+    // 1. 全プロジェクトを取得
+    const projectsSnapshot = await db.collection('projects').get();
+    const projects = [];
+    projectsSnapshot.forEach(doc => {
+      projects.push({ id: doc.id, ...doc.data() });
+    });
+
+    console.log(`📁 プロジェクト数: ${projects.length}\n`);
+
+    // 2. 全時間記録を取得してメモからコード候補を抽出
+    const timeEntriesSnapshot = await db.collection('timeEntries').get();
+    const notesCodes = new Map(); // projectId → most common code
+
+    const codePatterns = [
+      /([A-Z]{2,10}[-_]\d{1,5})/g,
+      /\[([A-Z0-9]{2,10}[-_]?\d{0,5})\]/g,
+    ];
+
+    timeEntriesSnapshot.forEach(doc => {
+      const entry = doc.data();
+      const notes = entry.notes || entry.description || '';
+      if (!notes.trim() || !entry.projectId) return;
+
+      for (const pattern of codePatterns) {
+        const matches = notes.matchAll(pattern);
+        for (const match of matches) {
+          const code = match[1] || match[0];
+          // プロジェクトコードとして使えそうなもの（サブコード形式 XXX-001-01 は除外）
+          if (code.split('-').length <= 2) {
+            if (!notesCodes.has(entry.projectId)) {
+              notesCodes.set(entry.projectId, new Map());
+            }
+            const codeCounts = notesCodes.get(entry.projectId);
+            codeCounts.set(code, (codeCounts.get(code) || 0) + 1);
+          }
+        }
+      }
+    });
+
+    // 3. 各プロジェクトのコードを決定
+    const existingCodes = new Set(projects.filter(p => p.code).map(p => p.code));
+    const updates = []; // { projectId, projectName, oldCode, newCode, tasks }
+
+    for (const project of projects) {
+      // 既にコードが設定済みで、--force でない場合はスキップ
+      if (project.code && !isForce && !manualCodes.has(project.id)) {
+        console.log(`  ✅ ${project.name}: 既存コード「${project.code}」を保持`);
+        continue;
+      }
+
+      let newCode = null;
+
+      // 優先度1: 手動指定
+      if (manualCodes.has(project.id)) {
+        newCode = manualCodes.get(project.id);
+      }
+
+      // 優先度2: メモから抽出したコード
+      if (!newCode && notesCodes.has(project.id)) {
+        const codeCounts = notesCodes.get(project.id);
+        // 最も頻出のコードを使用
+        let maxCount = 0;
+        for (const [code, count] of codeCounts) {
+          if (count > maxCount && !existingCodes.has(code)) {
+            maxCount = count;
+            newCode = code;
+          }
+        }
+        if (newCode) {
+          console.log(`  🔍 ${project.name}: メモから検出「${newCode}」（${maxCount}回出現）`);
+        }
+      }
+
+      // 優先度3: プロジェクト名から自動生成
+      if (!newCode) {
+        newCode = generateCodeFromName(project.name, existingCodes);
+        console.log(`  🔄 ${project.name}: 名前から自動生成「${newCode}」`);
+      }
+
+      existingCodes.add(newCode);
+
+      // タスクのサブコード生成
+      const tasks = (project.tasks || []).map((task, index) => ({
+        ...task,
+        subCode: task.subCode && !isForce
+          ? task.subCode
+          : `${newCode}-${String(index + 1).padStart(2, '0')}`
+      }));
+
+      updates.push({
+        projectId: project.id,
+        projectName: project.name,
+        oldCode: project.code || '(なし)',
+        newCode,
+        tasks
+      });
+    }
+
+    // 4. 変更内容の表示
+    console.log('\n\n📋 変更内容:');
+    console.log('─'.repeat(60));
+
+    if (updates.length === 0) {
+      console.log('  変更なし（全プロジェクトにコードが設定済み）');
+      console.log('  → --force オプションで上書き可能');
+      process.exit(0);
+      return;
+    }
+
+    for (const update of updates) {
+      console.log(`\n  プロジェクト: ${update.projectName}`);
+      console.log(`    コード: ${update.oldCode} → ${update.newCode}`);
+      update.tasks.forEach(t => {
+        console.log(`    タスク「${t.name}」: サブコード → ${t.subCode}`);
+      });
+    }
+
+    console.log('\n' + '─'.repeat(60));
+    console.log(`  合計: ${updates.length}件のプロジェクトを更新`);
+
+    // 5. Dry-run の場合はここで終了
+    if (isDryRun) {
+      console.log('\n⚠️  プレビューモードです。実際に登録するには --dry-run を外して実行してください。');
+      process.exit(0);
+      return;
+    }
+
+    // 6. Firestoreに書き込み
+    console.log('\n🔄 Firestoreに書き込み中...');
+
+    // Firestoreバッチは最大500操作なのでチャンクに分割
+    const chunkSize = 500;
+    for (let i = 0; i < updates.length; i += chunkSize) {
+      const chunk = updates.slice(i, i + chunkSize);
+      const batch = db.batch();
+
+      for (const update of chunk) {
+        const ref = db.collection('projects').doc(update.projectId);
+        batch.update(ref, {
+          code: update.newCode,
+          tasks: update.tasks,
+          updatedAt: Timestamp.now()
+        });
+      }
+
+      await batch.commit();
+      console.log(`  バッチ ${Math.floor(i / chunkSize) + 1}: ${chunk.length}件完了`);
+    }
+
+    console.log('\n✅ プロジェクトコードの一括登録が完了しました！');
+    console.log('\n📌 確認方法:');
+    console.log('  - プロジェクト管理画面でコードを確認できます');
+    console.log('  - 時間登録画面のドロップダウンにコードが表示されます');
+    console.log('  - レポートのCSVエクスポートにコードが含まれます');
+
+  } catch (error) {
+    console.error('エラー:', error);
+  }
+
+  process.exit(0);
+}
+
+registerProjectCodes();

--- a/server/scan-notes-for-codes.mjs
+++ b/server/scan-notes-for-codes.mjs
@@ -1,0 +1,140 @@
+/**
+ * 既存の時間記録のメモ（notes）からプロジェクトコード候補を抽出するスクリプト
+ *
+ * このスクリプトはデータの確認のみ（読み取り専用）で、変更は行いません。
+ *
+ * 実行方法:
+ *   cd server
+ *   GOOGLE_CLOUD_PROJECT=harvest-a82c0 node scan-notes-for-codes.mjs
+ */
+
+import { Firestore } from '@google-cloud/firestore';
+
+const projectId = 'harvest-a82c0';
+const db = new Firestore({ projectId });
+
+async function scanNotesForCodes() {
+  try {
+    console.log('=== 既存データスキャン開始 ===\n');
+
+    // 1. 全プロジェクトを取得
+    const projectsSnapshot = await db.collection('projects').get();
+    const projects = [];
+    projectsSnapshot.forEach(doc => {
+      projects.push({ id: doc.id, ...doc.data() });
+    });
+
+    console.log(`📁 プロジェクト数: ${projects.length}`);
+    console.log('---');
+
+    // プロジェクト一覧と現在のコード状況
+    console.log('\n📋 プロジェクト一覧（現在のコード設定状況）:');
+    projects.forEach(p => {
+      const code = p.code || '(未設定)';
+      const taskInfo = (p.tasks || []).map(t => {
+        const subCode = t.subCode || '(未設定)';
+        return `    タスク: ${t.name} → サブコード: ${subCode}`;
+      }).join('\n');
+      console.log(`  [${code}] ${p.name} (ID: ${p.id})`);
+      if (taskInfo) console.log(taskInfo);
+    });
+
+    // 2. 全時間記録を取得
+    const timeEntriesSnapshot = await db.collection('timeEntries').get();
+    const timeEntries = [];
+    timeEntriesSnapshot.forEach(doc => {
+      timeEntries.push({ id: doc.id, ...doc.data() });
+    });
+
+    console.log(`\n⏱️  時間記録数: ${timeEntries.length}`);
+    console.log('---');
+
+    // 3. メモにコード的なパターンが含まれるエントリを抽出
+    // よくあるコードパターン: PRJ-001, ABC-123, #1234, [CODE], 等
+    const codePatterns = [
+      /([A-Z]{2,10}[-_]\d{1,5})/g,           // PRJ-001, ABC-123 形式
+      /\[([A-Z0-9]{2,10}[-_]?\d{0,5})\]/g,   // [PRJ001] [CODE-1] 形式
+      /#([A-Z0-9]{2,10}[-_]?\d{0,5})/g,      // #PRJ001 形式
+    ];
+
+    const notesWithCodes = new Map(); // projectId → Set of code candidates
+    const projectNotesSample = new Map(); // projectId → sample notes
+
+    timeEntries.forEach(entry => {
+      const notes = entry.notes || entry.description || '';
+      if (!notes.trim()) return;
+
+      const projectId = entry.projectId;
+      if (!projectId) return;
+
+      // メモのサンプルを保存（各プロジェクト最大5件）
+      if (!projectNotesSample.has(projectId)) {
+        projectNotesSample.set(projectId, []);
+      }
+      const samples = projectNotesSample.get(projectId);
+      if (samples.length < 5) {
+        samples.push(notes.substring(0, 100));
+      }
+
+      // コードパターンを検索
+      for (const pattern of codePatterns) {
+        const matches = notes.matchAll(pattern);
+        for (const match of matches) {
+          const code = match[1] || match[0];
+          if (!notesWithCodes.has(projectId)) {
+            notesWithCodes.set(projectId, new Set());
+          }
+          notesWithCodes.get(projectId).add(code);
+        }
+      }
+    });
+
+    // 4. 結果を表示
+    console.log('\n📝 プロジェクト別メモサンプル:');
+    for (const project of projects) {
+      const samples = projectNotesSample.get(project.id) || [];
+      if (samples.length > 0) {
+        console.log(`\n  プロジェクト: ${project.name} (ID: ${project.id})`);
+        console.log(`  現在のコード: ${project.code || '(未設定)'}`);
+        samples.forEach((s, i) => {
+          console.log(`    メモ${i + 1}: "${s}"`);
+        });
+      }
+    }
+
+    console.log('\n\n🔍 メモからコード候補を検出:');
+    if (notesWithCodes.size === 0) {
+      console.log('  コードパターンは検出されませんでした。');
+      console.log('  → メモの内容を確認して、手動でコードを設定するか、');
+      console.log('    register-project-codes.mjs でプロジェクト名ベースの自動生成を使用してください。');
+    } else {
+      for (const [pid, codes] of notesWithCodes) {
+        const project = projects.find(p => p.id === pid);
+        console.log(`  プロジェクト: ${project?.name || pid}`);
+        console.log(`    検出コード候補: ${[...codes].join(', ')}`);
+      }
+    }
+
+    // 5. コード未設定のプロジェクト一覧
+    const projectsWithoutCode = projects.filter(p => !p.code);
+    console.log(`\n\n⚠️  コード未設定のプロジェクト: ${projectsWithoutCode.length}件`);
+    projectsWithoutCode.forEach(p => {
+      console.log(`  - ${p.name} (ID: ${p.id})`);
+    });
+
+    // 6. 推奨アクション
+    console.log('\n\n💡 推奨アクション:');
+    console.log('  1. 上記の情報を確認してください');
+    console.log('  2. register-project-codes.mjs を使ってコードを一括登録できます');
+    console.log('     使い方:');
+    console.log('     GOOGLE_CLOUD_PROJECT=harvest-a82c0 node register-project-codes.mjs');
+    console.log('');
+
+  } catch (error) {
+    console.error('エラー:', error);
+  }
+
+  process.exit(0);
+}
+
+scanNotesForCodes();

--- a/server/src/controllers/reports.firestore.ts
+++ b/server/src/controllers/reports.firestore.ts
@@ -119,8 +119,9 @@ export const getTimeEntriesReport = async (req: AuthRequestFirestore, res: Respo
               projectInfo = {
                 id: project.id!,
                 name: project.name,
+                code: project.code || '',
                 client: null
-              };
+              } as any;
               
               if (project.clientId) {
                 const client = await Client.findById(project.clientId);
@@ -286,6 +287,7 @@ export const getProjectsReport = async (req: AuthRequestFirestore, res: Response
         project: {
           id: project.id,
           name: project.name,
+          code: project.code || '',
           status: project.status,
           client
         },

--- a/server/src/models/firestore/Project.ts
+++ b/server/src/models/firestore/Project.ts
@@ -4,6 +4,7 @@ import { Timestamp } from '@google-cloud/firestore';
 export interface ITask {
   id: string;
   name: string;
+  subCode?: string;
   hourlyRate?: number;
   isBillable: boolean;
 }
@@ -15,6 +16,7 @@ export interface IProjectMember {
 
 export interface IProject {
   id?: string;
+  code?: string;
   name: string;
   description?: string;
   clientId: string;
@@ -39,13 +41,15 @@ export class ProjectModel {
 
   async create(projectData: Omit<IProject, 'id' | 'createdAt' | 'updatedAt'>): Promise<IProject> {
     const now = Timestamp.now();
-    
-    // Ensure tasks have IDs
+
+    // Ensure tasks have IDs and subCodes
+    const projectCode = projectData.code || '';
     const tasksWithIds = projectData.tasks.map((task, index) => ({
       ...task,
-      id: task.id || `task_${Date.now()}_${index}`
+      id: task.id || `task_${Date.now()}_${index}`,
+      subCode: task.subCode || (projectCode ? `${projectCode}-${String(index + 1).padStart(2, '0')}` : '')
     }));
-    
+
     const project: Omit<IProject, 'id'> = {
       ...projectData,
       tasks: tasksWithIds,
@@ -167,11 +171,13 @@ export class ProjectModel {
       updatedAt: Timestamp.now()
     };
 
-    // Ensure tasks have IDs if updating tasks
+    // Ensure tasks have IDs and subCodes if updating tasks
     if (updateFields.tasks) {
+      const projectCode = updateFields.code || '';
       updateFields.tasks = updateFields.tasks.map((task, index) => ({
         ...task,
-        id: task.id || `task_${Date.now()}_${index}`
+        id: task.id || `task_${Date.now()}_${index}`,
+        subCode: task.subCode || (projectCode ? `${projectCode}-${String(index + 1).padStart(2, '0')}` : '')
       }));
     }
 

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -59,7 +59,8 @@ const Projects = () => {
 
   const filteredProjects = projects.filter(project =>
     project.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                (project.clientName || '').toLowerCase().includes(searchTerm.toLowerCase()) // clientNameで検索（Firestore版）
+    (project.code || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+    (project.clientName || '').toLowerCase().includes(searchTerm.toLowerCase())
   )
 
   const handleArchive = async (id: string) => {
@@ -87,6 +88,7 @@ const Projects = () => {
   }
 
   // --- Project Form State ---
+  const [projectCode, setProjectCode] = useState('')
   const [projectName, setProjectName] = useState('')
   const [clientId, setClientId] = useState('')
   const [description, setDescription] = useState('')
@@ -94,7 +96,7 @@ const Projects = () => {
   const [budget, setBudget] = useState<number | string>('')
   const [budgetType, setBudgetType] = useState<'hourly' | 'fixed'>('hourly')
   const [hourlyRate, setHourlyRate] = useState<number | string>('')
-  const [tasks, setTasks] = useState<Array<{ name: string; hourlyRate?: number; isBillable: boolean }>>([])
+  const [tasks, setTasks] = useState<Array<{ name: string; subCode?: string; hourlyRate?: number; isBillable: boolean }>>([])
   // --- Project Form State End ---
 
   // モーダル開閉時の初期化/設定
@@ -104,11 +106,12 @@ const Projects = () => {
       if (selectedProject) {
         console.log('Debug: Setting form for editing project');
         console.log('Debug: selectedProject.client =', selectedProject.client);
+        setProjectCode(selectedProject.code || '')
         setProjectName(selectedProject.name)
         // Firestore版とMongoDB版の両方に対応
         const clientIdValue = selectedProject.clientId || // Firestore版
-          (typeof selectedProject.client === 'string' 
-            ? selectedProject.client 
+          (typeof selectedProject.client === 'string'
+            ? selectedProject.client
             : (selectedProject.client?._id || selectedProject.client?.id)) || '';
         setClientId(clientIdValue)
         setDescription(selectedProject.description || '')
@@ -121,6 +124,7 @@ const Projects = () => {
       } else {
         console.log('Debug: Setting form for new project');
         // 新規作成時はフォームをリセット
+        setProjectCode('')
         setProjectName('')
         setClientId('')
         setDescription('')
@@ -201,6 +205,7 @@ const Projects = () => {
       }
 
       const projectData = {
+        code: projectCode,
         name: projectName,
         client: clientId, // API expects 'client' field
         clientId: clientId, // Keep for backward compatibility
@@ -247,7 +252,9 @@ const Projects = () => {
 
   // タスク管理のヘルパー関数
   const addTask = () => {
-    setTasks([...tasks, { name: '', hourlyRate: 0, isBillable: true }])
+    const nextIndex = tasks.length + 1;
+    const autoSubCode = projectCode ? `${projectCode}-${String(nextIndex).padStart(2, '0')}` : '';
+    setTasks([...tasks, { name: '', subCode: autoSubCode, hourlyRate: 0, isBillable: true }])
   }
 
   const updateTask = (index: number, field: string, value: any) => {
@@ -292,7 +299,7 @@ const Projects = () => {
             <Icon as={MdSearch} color="gray.400" />
           </InputLeftElement>
           <Input
-            placeholder="Search projects (name, client)"
+            placeholder="Search projects (code, name, client)"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -303,6 +310,7 @@ const Projects = () => {
         <Table variant="simple">
           <Thead>
             <Tr>
+              <Th>Code</Th>
               <Th>Name</Th>
               <Th>Client</Th>
               <Th>Status</Th>
@@ -317,6 +325,13 @@ const Projects = () => {
 
               return (
                 <Tr key={project._id || project.id}>
+                  <Td>
+                    {project.code ? (
+                      <Badge colorScheme="purple" fontSize="xs">{project.code}</Badge>
+                    ) : (
+                      <Text color="gray.400" fontSize="xs">-</Text>
+                    )}
+                  </Td>
                   <Td fontWeight="medium">{project.name}</Td>
                   <Td>{clientName}</Td>
                   <Td>
@@ -368,14 +383,25 @@ const Projects = () => {
           <ModalBody pb={6}>
             <Box as="form" onSubmit={(e: React.FormEvent<HTMLDivElement>) => e.preventDefault()}>
               <VStack spacing={4}>
-                <FormControl isRequired>
-                  <FormLabel>Project Name</FormLabel>
-                  <Input
-                    placeholder="Enter project name"
-                    value={projectName}
-                    onChange={(e) => setProjectName(e.target.value)}
-                  />
-                </FormControl>
+                <HStack w="full" spacing={4}>
+                  <FormControl flex={1}>
+                    <FormLabel>Project Code</FormLabel>
+                    <Input
+                      placeholder="e.g. PRJ-001"
+                      value={projectCode}
+                      onChange={(e) => setProjectCode(e.target.value.toUpperCase())}
+                      size="md"
+                    />
+                  </FormControl>
+                  <FormControl flex={2} isRequired>
+                    <FormLabel>Project Name</FormLabel>
+                    <Input
+                      placeholder="Enter project name"
+                      value={projectName}
+                      onChange={(e) => setProjectName(e.target.value)}
+                    />
+                  </FormControl>
+                </HStack>
 
                 <FormControl isRequired>
                   <FormLabel>Client</FormLabel>
@@ -472,39 +498,49 @@ const Projects = () => {
                   ) : (
                     <VStack spacing={3} align="stretch">
                       {tasks.map((task, index) => (
-                        <HStack key={index} spacing={2} p={3} border="1px" borderColor="gray.200" borderRadius="md">
-                          <Input
-                            placeholder="Task name"
-                            value={task.name}
-                            onChange={(e) => updateTask(index, 'name', e.target.value)}
-                            size="sm"
-                            flex={2}
-                          />
-                          <NumberInput
-                            size="sm"
-                            min={0}
-                            flex={1}
-                            value={task.hourlyRate || ''}
-                            onChange={(value) => updateTask(index, 'hourlyRate', parseFloat(value) || 0)}
-                          >
-                            <NumberInputField placeholder="Rate" />
-                          </NumberInput>
-                          <Checkbox
-                            isChecked={task.isBillable}
-                            onChange={(e) => updateTask(index, 'isBillable', e.target.checked)}
-                          >
-                            Billable
-                          </Checkbox>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            colorScheme="red"
-                            onClick={() => removeTask(index)}
-                            type="button"
-                          >
-                            <MdDelete />
-                          </Button>
-                        </HStack>
+                        <Box key={index} p={3} border="1px" borderColor="gray.200" borderRadius="md">
+                          <HStack spacing={2} mb={2}>
+                            <Input
+                              placeholder="Sub Code"
+                              value={task.subCode || ''}
+                              onChange={(e) => updateTask(index, 'subCode', e.target.value.toUpperCase())}
+                              size="sm"
+                              flex={1}
+                              maxW="120px"
+                            />
+                            <Input
+                              placeholder="Task name"
+                              value={task.name}
+                              onChange={(e) => updateTask(index, 'name', e.target.value)}
+                              size="sm"
+                              flex={2}
+                            />
+                            <NumberInput
+                              size="sm"
+                              min={0}
+                              flex={1}
+                              value={task.hourlyRate || ''}
+                              onChange={(value) => updateTask(index, 'hourlyRate', parseFloat(value) || 0)}
+                            >
+                              <NumberInputField placeholder="Rate" />
+                            </NumberInput>
+                            <Checkbox
+                              isChecked={task.isBillable}
+                              onChange={(e) => updateTask(index, 'isBillable', e.target.checked)}
+                            >
+                              Billable
+                            </Checkbox>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              colorScheme="red"
+                              onClick={() => removeTask(index)}
+                              type="button"
+                            >
+                              <MdDelete />
+                            </Button>
+                          </HStack>
+                        </Box>
                       ))}
                     </VStack>
                   )}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -132,10 +132,11 @@ const Reports = () => {
     const summary = reportData.reduce((acc, entry) => {
       const projectId = entry.project?.id || entry.projectId || '';
       if (!acc[projectId]) {
-        // Get client name from projects list
+        // Get client name and code from projects list
         const projectData = projects.find(p => p.id === projectId);
         acc[projectId] = {
           project: entry.project || { id: projectId, name: entry.projectName || 'Unknown' },
+          projectCode: projectData?.code || '',
           clientName: projectData?.clientName || 'Unknown Client',
           totalHours: 0,
           billableHours: 0,
@@ -173,26 +174,43 @@ const Reports = () => {
     return map;
   }, [projects]);
 
+  // Create a map of project ID to project code
+  const projectCodeMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    projects.forEach(project => {
+      if (project.id) {
+        map[project.id] = project.code || '';
+      }
+    });
+    return map;
+  }, [projects]);
+
   // Daily entries sorted by date
   const dailyEntries = useMemo(() => {
     return reportData
       .map(entry => {
         const hours = entry.hours || ((entry.duration || 0) / 3600);
         const projectId = entry.project?.id || entry.projectId || '';
+        const projectData = projects.find(p => p.id === projectId);
+        const taskName = typeof entry.task === 'string' ? entry.task : (entry.task as any)?.name || '-';
+        const taskData = projectData?.tasks?.find(t => t.name === taskName);
         return {
           ...entry,
           calculatedHours: hours,
+          projectCode: projectCodeMap[projectId] || '',
           projectName: entry.project?.name || entry.projectName || 'Unknown',
-          clientName: projectClientMap[projectId] || 'Unknown Client'
+          clientName: projectClientMap[projectId] || 'Unknown Client',
+          taskSubCode: taskData?.subCode || ''
         };
       })
       .sort((a, b) => {
-        // Sort by date (ascending), then by project name
+        // Sort by date (ascending), then by project code/name
         const dateCompare = new Date(a.date).getTime() - new Date(b.date).getTime();
         if (dateCompare !== 0) return dateCompare;
+        if (a.projectCode && b.projectCode) return a.projectCode.localeCompare(b.projectCode);
         return a.projectName.localeCompare(b.projectName);
       });
-  }, [reportData, projectClientMap]);
+  }, [reportData, projectClientMap, projectCodeMap, projects]);
 
   // Calculate total statistics
   const totalStats = useMemo(() => {
@@ -223,24 +241,24 @@ const Reports = () => {
     // Export based on active tab
     if (activeTab === 1) {
       // Daily Breakdown
-      csvContent = 'Date,Day,Client,Project,Task,Notes,Hours,Type\n';
+      csvContent = 'Date,Day,Project Code,Client,Project,Sub Code,Task,Notes,Hours,Type\n';
       dailyEntries.forEach(entry => {
         const dateInfo = formatDateWithDay(entry.date);
         const notes = entry.notes || entry.description || '-';
-        csvContent += `"${dateInfo.formatted}","${dateInfo.dayOfWeek}","${entry.clientName}","${entry.projectName}","${entry.task || '-'}","${notes}",${entry.calculatedHours.toFixed(2)},"${entry.isBillable ? 'Billable' : 'Non-Billable'}"\n`;
+        csvContent += `"${dateInfo.formatted}","${dateInfo.dayOfWeek}","${entry.projectCode || ''}","${entry.clientName}","${entry.projectName}","${entry.taskSubCode || ''}","${entry.task || '-'}","${notes}",${entry.calculatedHours.toFixed(2)},"${entry.isBillable ? 'Billable' : 'Non-Billable'}"\n`;
       });
       filename = 'daily-breakdown-report.csv';
     } else if (activeTab === 2) {
       // Project Summary
-      csvContent = 'Client,Project,Total Hours,Billable Hours,Non-Billable Hours,Billable %,Team Members\n';
+      csvContent = 'Project Code,Client,Project,Total Hours,Billable Hours,Non-Billable Hours,Billable %,Team Members\n';
       projectSummary.forEach(project => {
         const billablePercentage = project.totalHours > 0 ? (project.billableHours / project.totalHours) * 100 : 0;
-        csvContent += `"${project.clientName}","${project.project.name}",${project.totalHours.toFixed(2)},${project.billableHours.toFixed(2)},${(project.totalHours - project.billableHours).toFixed(2)},${billablePercentage.toFixed(0)}%,${project.userCount}\n`;
+        csvContent += `"${project.projectCode || ''}","${project.clientName}","${project.project.name}",${project.totalHours.toFixed(2)},${project.billableHours.toFixed(2)},${(project.totalHours - project.billableHours).toFixed(2)},${billablePercentage.toFixed(0)}%,${project.userCount}\n`;
       });
       filename = 'project-summary-report.csv';
     } else {
       // Time Summary - Export raw data (sorted by date ascending)
-      csvContent = 'Date,Client,Project,Task,Notes,Hours,Billable\n';
+      csvContent = 'Date,Project Code,Client,Project,Sub Code,Task,Notes,Hours,Billable\n';
       const sortedData = [...reportData].sort((a, b) =>
         new Date(a.date).getTime() - new Date(b.date).getTime()
       );
@@ -248,7 +266,12 @@ const Reports = () => {
         const hours = entry.hours || ((entry.duration || 0) / 3600);
         const projectId = entry.project?.id || entry.projectId || '';
         const clientName = projectClientMap[projectId] || 'Unknown Client';
-        csvContent += `"${entry.date}","${clientName}","${entry.project?.name || entry.projectName || 'Unknown'}","${entry.task || '-'}","${entry.notes || entry.description || '-'}",${hours.toFixed(2)},${entry.isBillable ? 'Yes' : 'No'}\n`;
+        const pCode = projectCodeMap[projectId] || '';
+        const projectData = projects.find(p => p.id === projectId);
+        const taskName = typeof entry.task === 'string' ? entry.task : (entry.task as any)?.name || '-';
+        const taskData = projectData?.tasks?.find(t => t.name === taskName);
+        const subCode = taskData?.subCode || '';
+        csvContent += `"${entry.date}","${pCode}","${clientName}","${entry.project?.name || entry.projectName || 'Unknown'}","${subCode}","${taskName}","${entry.notes || entry.description || '-'}",${hours.toFixed(2)},${entry.isBillable ? 'Yes' : 'No'}\n`;
       });
       filename = 'time-entries-report.csv';
     }
@@ -271,7 +294,7 @@ const Reports = () => {
       duration: 3000,
       isClosable: true
     });
-  }, [reportGenerated, reportData, activeTab, dailyEntries, projectSummary]);
+  }, [reportGenerated, reportData, activeTab, dailyEntries, projectSummary, projectClientMap, projectCodeMap, projects]);
 
   if (projectsLoading || usersLoading) {
     return (
@@ -327,7 +350,9 @@ const Reports = () => {
                   <Select value={selectedProject} onChange={(e) => setSelectedProject(e.target.value)}>
                     <option value="all">All Projects</option>
                     {projects.map(project => (
-                      <option key={project.id} value={project.id}>{project.name}</option>
+                      <option key={project.id} value={project.id}>
+                        {project.code ? `[${project.code}] ` : ''}{project.name}
+                      </option>
                     ))}
                   </Select>
                 </FormControl>
@@ -422,7 +447,9 @@ const Reports = () => {
                             <Tr>
                               <Th>Date</Th>
                               <Th>Day</Th>
+                              <Th>Code</Th>
                               <Th>Project</Th>
+                              <Th>Sub Code</Th>
                               <Th>Task</Th>
                               <Th isNumeric>Hours</Th>
                               <Th>Type</Th>
@@ -439,7 +466,17 @@ const Reports = () => {
                                       {dateInfo.dayOfWeek}
                                     </Badge>
                                   </Td>
+                                  <Td>
+                                    {entry.projectCode ? (
+                                      <Badge colorScheme="purple" fontSize="xs">{entry.projectCode}</Badge>
+                                    ) : '-'}
+                                  </Td>
                                   <Td>{entry.projectName}</Td>
+                                  <Td>
+                                    {entry.taskSubCode ? (
+                                      <Badge colorScheme="teal" fontSize="xs">{entry.taskSubCode}</Badge>
+                                    ) : '-'}
+                                  </Td>
                                   <Td>{typeof entry.task === 'string' ? entry.task : (entry.task ? 'Task' : '-')}</Td>
                                   <Td isNumeric>{formatHours(entry.calculatedHours)}</Td>
                                   <Td>
@@ -473,6 +510,7 @@ const Reports = () => {
                         <Table variant="simple">
                           <Thead>
                             <Tr>
+                              <Th>Code</Th>
                               <Th>Project</Th>
                               <Th isNumeric>Total Hours</Th>
                               <Th isNumeric>Billable Hours</Th>
@@ -483,11 +521,16 @@ const Reports = () => {
                           </Thead>
                           <Tbody>
                             {projectSummary.map((project) => {
-                              const billablePercentage = project.totalHours > 0 
-                                ? (project.billableHours / project.totalHours) * 100 
+                              const billablePercentage = project.totalHours > 0
+                                ? (project.billableHours / project.totalHours) * 100
                                 : 0;
                               return (
                                 <Tr key={project.project.id}>
+                                  <Td>
+                                    {project.projectCode ? (
+                                      <Badge colorScheme="purple" fontSize="xs">{project.projectCode}</Badge>
+                                    ) : '-'}
+                                  </Td>
                                   <Td>{project.project.name}</Td>
                                   <Td isNumeric>{formatHours(project.totalHours)}</Td>
                                   <Td isNumeric>{formatHours(project.billableHours)}</Td>

--- a/src/pages/TimeTracking.tsx
+++ b/src/pages/TimeTracking.tsx
@@ -493,6 +493,25 @@ const TimeTracking = () => {
     return filterByClient(filterByProject(entries));
   };
 
+  // エントリーからプロジェクトコード付きの名前を取得
+  const getProjectDisplayName = (entry: TimeEntry) => {
+    const projectId = entry.projectId || entry.project?._id || entry.project?.id;
+    const project = projects.find(p => (p._id || p.id) === projectId);
+    const code = project?.code;
+    const name = entry.project?.name || entry.projectName || 'Unknown Project';
+    return code ? `[${code}] ${name}` : name;
+  };
+
+  // エントリーからタスクのサブコード付きの名前を取得
+  const getTaskDisplayName = (entry: TimeEntry) => {
+    const taskName = typeof entry.task === 'string' ? entry.task : entry.task?.name;
+    const projectId = entry.projectId || entry.project?._id || entry.project?.id;
+    const project = projects.find(p => (p._id || p.id) === projectId);
+    const task = project?.tasks?.find(t => t.name === taskName);
+    const subCode = task?.subCode;
+    return subCode ? `[${subCode}] ${taskName || '-'}` : (taskName || '-');
+  };
+
   // Filter time entries for today
   const getTodayEntries = () => {
     const today = getTodayDateString();
@@ -901,7 +920,9 @@ const TimeTracking = () => {
                   }}
                 >
                   {projects.map(project => (
-                    <option key={project._id || project.id} value={project._id || project.id}>{project.name}</option>
+                    <option key={project._id || project.id} value={project._id || project.id}>
+                      {project.code ? `[${project.code}] ` : ''}{project.name}
+                    </option>
                   ))}
                 </Select>
               </FormControl>
@@ -917,7 +938,9 @@ const TimeTracking = () => {
                   {tasks.map(task => {
                     const taskId = task._id || task.id || task.name;
                     return (
-                      <option key={taskId} value={taskId}>{task.name}</option>
+                      <option key={taskId} value={taskId}>
+                        {task.subCode ? `[${task.subCode}] ` : ''}{task.name}
+                      </option>
                     );
                   })}
                 </Select>
@@ -1095,7 +1118,7 @@ const TimeTracking = () => {
             >
               {projects.map(project => (
                 <option key={project._id || project.id} value={project._id || project.id}>
-                  {project.name}
+                  {project.code ? `[${project.code}] ` : ''}{project.name}
                 </option>
               ))}
             </Select>
@@ -1154,8 +1177,8 @@ const TimeTracking = () => {
                     {getTodayEntries().map(entry => (
                       <Tr key={entry._id || entry.id}>
                         <Td>{entry.date}</Td>
-                        <Td>{entry.project?.name || entry.projectName || 'Unknown Project'}</Td>
-                        <Td>{typeof entry.task === 'string' ? entry.task : entry.task?.name}</Td>
+                        <Td>{getProjectDisplayName(entry)}</Td>
+                        <Td>{getTaskDisplayName(entry)}</Td>
                         <Td>{entry.notes || entry.description || '-'}</Td>
                         <Td>{entry.isRunning ? formatTime(getElapsedTime(entry.startTime, entry.duration || 0)) : (entry.hours !== undefined && entry.hours !== null && entry.hours > 0 ? formatTime(entry.hours * 3600) : formatTime(entry.duration || 0))}</Td>
                         <Td>
@@ -1217,8 +1240,8 @@ const TimeTracking = () => {
                     {getWeekEntries().map(entry => (
                       <Tr key={entry._id || entry.id}>
                         <Td>{entry.date}</Td>
-                        <Td>{entry.project?.name || entry.projectName || 'Unknown Project'}</Td>
-                        <Td>{typeof entry.task === 'string' ? entry.task : entry.task?.name}</Td>
+                        <Td>{getProjectDisplayName(entry)}</Td>
+                        <Td>{getTaskDisplayName(entry)}</Td>
                         <Td>{entry.notes || entry.description || '-'}</Td>
                         <Td>{entry.isRunning ? formatTime(getElapsedTime(entry.startTime, entry.duration || 0)) : (entry.hours !== undefined && entry.hours !== null && entry.hours > 0 ? formatTime(entry.hours * 3600) : formatTime(entry.duration || 0))}</Td>
                         <Td>
@@ -1280,8 +1303,8 @@ const TimeTracking = () => {
                     {getMonthEntries().map(entry => (
                       <Tr key={entry._id || entry.id}>
                         <Td>{entry.date}</Td>
-                        <Td>{entry.project?.name || entry.projectName || 'Unknown Project'}</Td>
-                        <Td>{typeof entry.task === 'string' ? entry.task : entry.task?.name}</Td>
+                        <Td>{getProjectDisplayName(entry)}</Td>
+                        <Td>{getTaskDisplayName(entry)}</Td>
                         <Td>{entry.notes || entry.description || '-'}</Td>
                         <Td>{entry.isRunning ? formatTime(getElapsedTime(entry.startTime, entry.duration || 0)) : (entry.hours !== undefined && entry.hours !== null && entry.hours > 0 ? formatTime(entry.hours * 3600) : formatTime(entry.duration || 0))}</Td>
                         <Td>
@@ -1356,8 +1379,8 @@ const TimeTracking = () => {
                       {paginatedEntries.map(entry => (
                         <Tr key={entry._id || entry.id}>
                           <Td>{entry.date}</Td>
-                          <Td>{entry.project?.name || entry.projectName || 'Unknown Project'}</Td>
-                          <Td>{typeof entry.task === 'string' ? entry.task : entry.task?.name}</Td>
+                          <Td>{getProjectDisplayName(entry)}</Td>
+                          <Td>{getTaskDisplayName(entry)}</Td>
                           <Td>{entry.notes || '-'}</Td>
                           <Td>{entry.isRunning ? 'Running' : (entry.hours !== undefined && entry.hours !== null && entry.hours > 0 ? formatTime(entry.hours * 3600) : formatTime(entry.duration || 0))}</Td>
                           <Td>

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -716,6 +716,7 @@ export interface components {
         Task: {
             id?: string;
             _id?: string;
+            subCode?: string;
             name?: string;
             description?: string;
             rate?: number;
@@ -729,6 +730,7 @@ export interface components {
         Project: {
             id?: string;
             _id?: string;
+            code?: string;
             name?: string;
             description?: string;
             client?: string;
@@ -752,6 +754,7 @@ export interface components {
         };
         CreateProjectRequest: {
             name: string;
+            code?: string;
             description?: string;
             client?: string;
             /**
@@ -767,6 +770,7 @@ export interface components {
             hourlyRate?: number;
             tasks?: {
                 name?: string;
+                subCode?: string;
                 description?: string;
                 rate?: number;
                 isBillable?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export interface User {
 export interface Project {
   id: string;
   _id?: string; // For backward compatibility
+  code?: string; // プロジェクトコード（例: "PRJ-001"）
   name: string;
   client?: Client | string; // MongoDB版で使用（オプショナル）
   clientId?: string; // Firestore版で使用
@@ -34,6 +35,7 @@ export interface Project {
 export interface Task {
   id?: string; // Add id property
   _id?: string; // For backward compatibility
+  subCode?: string; // サブコード（例: "PRJ-001-01"）
   name: string;
   description?: string;
   rate?: number;


### PR DESCRIPTION
プロジェクトにcode（例: PRJ-001）、タスクにsubCode（例: PRJ-001-01）を追加。
レポートやCSVエクスポートでコードを表示し、各ツールで紐づけ可能に。

- Backend: IProject.code, ITask.subCode フィールド追加、自動生成ロジック
- Frontend: Projects/TimeTracking/Reports でコード表示・入力対応
- CSV: Project Code, Sub Code カラム追加
- 検索: プロジェクトコードでの検索対応

https://claude.ai/code/session_0177fv3YPr4e2JC1axD3aBki