### PR TITLE
Change default tab index from 0 to 1 in TimeTracking

### DIFF
--- a/src/pages/TimeTracking.tsx
+++ b/src/pages/TimeTracking.tsx
@@ -278,7 +278,7 @@ const TimeTracking = () => {
   });
   const [duration, setDuration] = useState<string>('');
   const [notes, setNotes] = useState<string>('');
-  const [tabIndex, setTabIndex] = useState<number>(0);
+  const [tabIndex, setTabIndex] = useState<number>(1);
   const [selectedTimeEntry, setSelectedTimeEntry] = useState<TimeEntry | null>(null); // 編集用
   const [currentTime, setCurrentTime] = useState<Date>(new Date()); // リアルタイム時間表示用
   const [currentPage, setCurrentPage] = useState<number>(1);


### PR DESCRIPTION
## Summary
Updated the default tab index in the TimeTracking component to display the second tab (index 1) instead of the first tab (index 0) on initial page load.

## Changes
- Changed initial `tabIndex` state from `0` to `1` in the TimeTracking component

## Details
This change affects the default view users see when navigating to the TimeTracking page. The component will now render with the second tab selected by default rather than the first tab.

https://claude.ai/code/session_01DLbDeH3s9mVn7BKSJWYcq4